### PR TITLE
PCC-68: Setup status api.

### DIFF
--- a/pcx_connect.routing.yml
+++ b/pcx_connect.routing.yml
@@ -1,0 +1,6 @@
+pcx_connect.api_status:
+  path: '/api/pantheoncloud/status'
+  defaults:
+    _controller: '\Drupal\pcx_connect\Controller\ApiStatusController::emptyResponse'
+  requirements:
+    _access: 'TRUE'

--- a/src/Controller/ApiStatusController.php
+++ b/src/Controller/ApiStatusController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Drupal\pcx_connect\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+/**
+ * Api Status Controller responsible for returning response for pcc site status endpoint.
+ */
+class ApiStatusController extends ControllerBase {
+
+  /**
+   * Returns empty response.
+   *
+   * @return JsonResponse
+   *   Empty JSON response.
+   */
+  public function emptyResponse() {
+    return new JsonResponse();
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced a new API endpoint at `/api/pantheoncloud/status` to provide status information.
  - Added a controller to handle the new API endpoint with a JSON response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->