### PR TITLE
PCC-68: Adding get-all-articles-demo and get-site debug endpoints.

### DIFF
--- a/pcx_connect.routing.yml
+++ b/pcx_connect.routing.yml
@@ -36,3 +36,17 @@ pcx_connect.api_status:
     _controller: '\Drupal\pcx_connect\Controller\ApiStatusController::emptyResponse'
   requirements:
     _access: 'TRUE'
+
+pcx_connect.get_site:
+  path: '/api/pantheoncloud/debug/get-site'
+  defaults:
+    _controller: '\Drupal\pcx_connect\Controller\DebugSiteController::getSite'
+  requirements:
+    _permission: 'administer pcc configurations'
+
+pcx_connect.get_all_articles:
+  path: '/api/pantheoncloud/debug/get-all-articles-demo'
+  defaults:
+    _controller: '\Drupal\pcx_connect\Controller\DebugSiteController::getAllArticles'
+  requirements:
+    _permission: 'administer pcc configurations'

--- a/src/Controller/ApiStatusController.php
+++ b/src/Controller/ApiStatusController.php
@@ -19,5 +19,4 @@ class ApiStatusController extends ControllerBase {
   public function emptyResponse() {
     return new JsonResponse();
   }
-
 }

--- a/src/Controller/DebugSiteController.php
+++ b/src/Controller/DebugSiteController.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Drupal\pcx_connect\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use PccPhpSdk\api\ContentApi;
+use PccPhpSdk\api\SiteApi;
+use PccPhpSdk\core\PccClient;
+use PccPhpSdk\core\PccClientConfig;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Debug Site Controller.
+ */
+class DebugSiteController extends ControllerBase {
+
+  /**
+   * The request stack.
+   *
+   * @var RequestStack
+   */
+  protected RequestStack $requestStack;
+
+  /**
+   * The Pcc Client.
+   *
+   * @var PccClient
+   */
+  protected PccClient $pccClient;
+
+  /**
+   * Constructs an UpdateRootFactory instance.
+   *
+   * @param RequestStack $requestStack
+   *   Request Stack.
+   */
+  public function __construct(RequestStack $requestStack) {
+    $this->requestStack = $requestStack;
+    $this->pccClient = new PccClient(
+      new PccClientConfig(
+        $this->getSiteID(),
+        $this->getSiteToken()
+      )
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @param ContainerInterface $container
+   *   The Drupal service container.
+   *
+   * @return static
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('request_stack')
+    );
+  }
+
+  /**
+   * Get site info.
+   *
+   * @return JsonResponse
+   *   JsonResponse with site info from Pcc.
+   */
+  public function getSite(): JsonResponse {
+    $siteId = $this->getSiteID();
+    $contentApi = new SiteApi($this->pccClient);
+    $content = $contentApi->getSite($siteId);
+
+    return new JsonResponse(
+      $content,
+      200,
+      [],
+      true
+    );
+  }
+
+  /**
+   * Get all articles.
+   *
+   * @return JsonResponse
+   *   JsonResponse with all articles.
+   */
+  public function getAllArticles(): JsonResponse {
+    $contentApi = new ContentApi($this->pccClient);
+    $content = $contentApi->getAllArticles();
+
+    return new JsonResponse(
+      $content,
+      200,
+      [],
+      true
+    );
+  }
+
+  /**
+   * Get Site ID from query.
+   *
+   * @return string|null
+   *   Site ID.
+   */
+  private function getSiteID(): ?string {
+    return $this->requestStack->getCurrentRequest()->query->get('site-id');
+  }
+
+  /**
+   * Get Site Token from query.
+   *
+   * @return string|null
+   *   Site Token.
+   */
+  private function getSiteToken(): ?string {
+    return $this->requestStack->getCurrentRequest()->query->get('site-token');
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced new methods in the Debug Site Controller to fetch site details and retrieve all articles.
- **Bug Fixes**
  - Removed an unnecessary empty line in the `emptyResponse()` method for cleaner code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->