### PR TITLE
PCC-91: Adding publishingLevel field and filter.

### DIFF
--- a/pcx_connect.views.inc
+++ b/pcx_connect.views.inc
@@ -164,12 +164,28 @@ function pcx_connect_views_data() {
           'id' => 'string',
         ],
       ];
+
       $table['tags'] = [
         'title' => $translation->translate('Tags'),
         'help' => $translation->translate('PCC Doc tags'),
         'field' => [
           'id' => 'pcc_tags',
           'click sortable' => FALSE,
+        ],
+        'filter' => [
+          'id' => 'string',
+        ],
+        'argument' => [
+          'id' => 'string',
+        ],
+      ];
+
+      $table['publishingLevel'] = [
+        'title' => $translation->translate('Publishing level'),
+        'help' => $translation->translate('PCC Doc Publishing level'),
+        'field' => [
+          'id' => 'standard',
+          'click sortable' => TRUE,
         ],
         'filter' => [
           'id' => 'string',

--- a/src/Controller/DebugSiteController.php
+++ b/src/Controller/DebugSiteController.php
@@ -9,6 +9,7 @@ use PccPhpSdk\api\Query\ArticleSearchArgs;
 use PccPhpSdk\api\Query\Enums\ArticleSortField;
 use PccPhpSdk\api\Query\Enums\ArticleSortOrder;
 use PccPhpSdk\api\Query\Enums\ContentType;
+use PccPhpSdk\api\Query\Enums\PublishingLevel;
 use PccPhpSdk\api\Query\Enums\PublishStatus;
 use PccPhpSdk\api\SitesApi;
 use PccPhpSdk\core\PccClient;
@@ -115,7 +116,8 @@ class DebugSiteController extends ControllerBase {
    */
   public function getArticleById(string $id): JsonResponse {
     $contentApi = new ArticlesApi($this->pccClient);
-    $response = $contentApi->getArticleById($id);
+    $publishingLevel = $this->getQueryArg('publishingLevel') ?? PublishingLevel::PRODUCTION;
+    $response = $contentApi->getArticleById($id, [], $publishingLevel);
     $content = json_encode($response);
 
     return new JsonResponse(
@@ -137,7 +139,8 @@ class DebugSiteController extends ControllerBase {
    */
   public function getArticleBySlug(string $slug): JsonResponse {
     $contentApi = new ArticlesApi($this->pccClient);
-    $response = $contentApi->getArticleBySlug($slug);
+    $publishingLevel = $this->getQueryArg('publishingLevel') ?? PublishingLevel::PRODUCTION;
+    $response = $contentApi->getArticleBySlug($slug, [], $publishingLevel);
     $content = json_encode($response);
 
     return new JsonResponse(

--- a/src/Pcc/Service/PccArticlesApi.php
+++ b/src/Pcc/Service/PccArticlesApi.php
@@ -6,6 +6,7 @@ use Drupal\Core\Logger\LoggerChannelFactory;
 use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\pcx_connect\Pcc\Mapper\PccArticlesMapperInterface;
 use PccPhpSdk\api\ArticlesApi;
+use PccPhpSdk\api\Query\Enums\PublishingLevel;
 use PccPhpSdk\Exception\PccClientException;
 
 /**
@@ -76,16 +77,23 @@ class PccArticlesApi implements PccArticlesApiInterface {
   /**
    * {@inheritDoc}
    */
-  public function getArticle(string $slug_or_id, string $siteId, string $siteToken, string $type, array $fields = []): mixed {
+  public function getArticle(
+    string $slug_or_id,
+    string $siteId,
+    string $siteToken,
+    string $type,
+    array $fields = [],
+    PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION
+  ): mixed {
     $api_client = $this->pccApiClient->getPccClient($siteId, $siteToken);
     $article_api = new ArticlesApi($api_client);
-    $article = [];
     if ($type == 'slug') {
-      $article = $article_api->getArticleBySlug($slug_or_id, $fields);
+      $article = $article_api->getArticleBySlug($slug_or_id, $fields, $publishingLevel);
     }
     else {
-      $article = $article_api->getArticleById($slug_or_id, $fields);
+      $article = $article_api->getArticleById($slug_or_id, $fields, $publishingLevel);
     }
+
     return $article;
   }
 

--- a/src/Pcc/Service/PccArticlesApiInterface.php
+++ b/src/Pcc/Service/PccArticlesApiInterface.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\pcx_connect\Pcc\Service;
 
+use PccPhpSdk\api\Query\Enums\PublishingLevel;
+
 /**
  * The PCC article api interface.
  */
@@ -20,10 +22,17 @@ interface PccArticlesApiInterface {
    * @return mixed
    *   Returns array of Articles in the form of Associative data.
    */
-  public function getAllArticles(string $siteId, string $siteToken, array $fields = []): array;
+  public function getAllArticles(
+    string $siteId,
+    string $siteToken,
+    array $fields = []
+  ): array;
 
   /**
-   * Get all articles.
+   * Get an article by slug or ID.
+   *
+   * This method retrieves an article based on the provided slug or ID. It allows
+   * specifying the publishing level to fetch articles according to their publishing state.
    *
    * @param string $slug_or_id
    *   Content slug or ID.
@@ -35,10 +44,19 @@ interface PccArticlesApiInterface {
    *   The filter type.
    * @param array $fields
    *   The API fields.
+   * @param PublishingLevel $publishingLevel
+   *   The publishing level of the article. Defaults to PublishingLevel::PRODUCTION if not specified.
    *
    * @return mixed
-   *   Returns array of Articles in the form of Associative data.
+   *   Returns an article in the form of associative data.
    */
-  public function getArticle(string $slug_or_id, string $siteId, string $siteToken, string $type, array $fields = []): mixed;
+  public function getArticle(
+    string $slug_or_id,
+    string $siteId,
+    string $siteToken,
+    string $type,
+    array $fields = [],
+    PublishingLevel $publishingLevel = PublishingLevel::PRODUCTION
+  ): mixed;
 
 }

--- a/src/Plugin/views/query/PccSiteViewQuery.php
+++ b/src/Plugin/views/query/PccSiteViewQuery.php
@@ -8,6 +8,7 @@ use Drupal\views\Plugin\views\display\DisplayPluginBase;
 use Drupal\views\Plugin\views\query\QueryPluginBase;
 use Drupal\views\ResultRow;
 use Drupal\views\ViewExecutable;
+use PccPhpSdk\api\Query\Enums\PublishingLevel;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -373,11 +374,26 @@ class PccSiteViewQuery extends QueryPluginBase {
    */
   protected function getArticleBySlugOrIdFromPccContentApi(ViewExecutable &$view, string $slug_or_id, string $type): void {
     $index = 0;
+    $publishingLevel = $this->getPublishingLevel();
     if ($type == 'slug') {
-      $article_data = $this->pccContentApi->getArticle($slug_or_id, $this->siteKey, $this->siteToken, 'slug', $this->fields);
+      $article_data = $this->pccContentApi->getArticle(
+        $slug_or_id,
+        $this->siteKey,
+        $this->siteToken,
+        'slug',
+        $this->fields,
+        $publishingLevel
+      );
     }
     else {
-      $article_data = $this->pccContentApi->getArticle($slug_or_id, $this->siteKey, $this->siteToken, 'id', $this->fields);
+      $article_data = $this->pccContentApi->getArticle(
+        $slug_or_id,
+        $this->siteKey,
+        $this->siteToken,
+        'id',
+        $this->fields,
+        $publishingLevel
+      );
     }
     $article = (array) $article_data;
     $view->result[] = $this->toRow($article, $index++);
@@ -407,6 +423,13 @@ class PccSiteViewQuery extends QueryPluginBase {
     }
     $row['index'] = $index;
     return new ResultRow($row);
+  }
+
+  protected function getPublishingLevel(): PublishingLevel {
+    return match ($this->contextualFilters['publishingLevel']) {
+      'realtime', 'REALTIME' => PublishingLevel::REALTIME,
+      default => PublishingLevel::PRODUCTION,
+    };
   }
 
 }


### PR DESCRIPTION
To preview content, we need to use publishingLevel flag for the API. And as we expect this parameter as part of URL query param, so we are adding Publishing Level field and contextual filter that can be added to views.

Corresponding PR: https://github.com/digitalpolygon/pcc-php-sdk/pull/11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for specifying publishing levels when retrieving articles, allowing users to filter content by publishing status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->