### PR TITLE
PCC-98: Remove pcc_site dependency.

### DIFF
--- a/config/optional/views.view.blogs.yml
+++ b/config/optional/views.view.blogs.yml
@@ -3,7 +3,6 @@ dependencies:
   config:
     - system.menu.main
   module:
-    - pcc_site
     - pcx_connect
     - user
 id: blogs

--- a/config/optional/views.view.pantheon_cloud_api.yml
+++ b/config/optional/views.view.pantheon_cloud_api.yml
@@ -1,7 +1,6 @@
 status: true
 dependencies:
   module:
-    - pcc_site
     - pcx_connect
 id: pantheon_cloud_api
 label: 'Pantheon Cloud API'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed obsolete `pcc_site` module dependencies from the blog and Pantheon Cloud API views for streamlined configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->