### PR TITLE
Update composer.json to refactor DP to Pantheon

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,20 @@
   "type": "drupal-module",
   "license": "GPL-2.0-or-later",
   "homepage": "https://drupal.org/project/pcx_connect",
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "git@github.com:pantheon-systems/pcc-php-sdk.git"
+    }
+  ],
   "extra": {
     "drush": {
       "services": {
         "drush.services.yml": "^9 || ^10 || ^11"
       }
     }
+  },
+  "require": {
+    "pantheon-systems/pcc-php-sdk": "^0.0.1"
   }
 }


### PR DESCRIPTION
1. Removes the references to DigitalPolygon from composer.json

Note: Once this PR is merged, you will need to update your existing Composer-based installation to point to the new Composer package name.

```
digitalpolygon/pcx_connect => pantheon-systems/pcx_connect
```