### PR TITLE
Update PccSiteViewQuery.php

### DIFF
--- a/src/Plugin/views/query/PccSiteViewQuery.php
+++ b/src/Plugin/views/query/PccSiteViewQuery.php
@@ -485,7 +485,7 @@ class PccSiteViewQuery extends QueryPluginBase {
   /**
    * Get Articles from Pcc Content API Service.
    */
-  protected function getArticlesFromPccContentApi(ViewExecutable &$view): void {
+  protected function getArticlesFromPccContentApi(ViewExecutable $view): void {
     $request = $this->requestStack->getCurrentRequest();
     // Convert to milliseconds.
     $default_cursor = (time() * 1000);
@@ -549,7 +549,7 @@ class PccSiteViewQuery extends QueryPluginBase {
   /**
    * Get Article from Pcc Content API Service.
    */
-  protected function getArticleBySlugOrIdFromPccContentApi(ViewExecutable &$view, string $slug_or_id, string $type): void {
+  protected function getArticleBySlugOrIdFromPccContentApi(ViewExecutable $view, string $slug_or_id, string $type): void {
     $field_keys = array_keys($this->fields);
     $index = 0;
     $publishingLevel = $this->getPublishingLevel();
@@ -592,13 +592,10 @@ class PccSiteViewQuery extends QueryPluginBase {
     $row = [];
     foreach ($article as $field => $value) {
       if ($value) {
-        $row[$field] = $value;
-        if ($field === 'publishedDate') {
-          $row[$field] = intdiv($value, 1000);
-        }
-        if ($field === 'updatedAt') {
-          $row[$field] = intdiv($value, 1000);
-        }
+        $row[$field] = match ($field) {
+          'publishedDate', 'updatedAt' => intdiv($value, 1000),
+          default => $value,
+        };
       }
     }
     $row['index'] = $index;


### PR DESCRIPTION
I didn't want to file a PR for every tiny edit.

There's no reason to take an object by reference unless you want to replace the object itself.

`getPublishingLevel` already uses `match` so why not.

However, `toRow` collecting into a row key called `index` makes me wonder a little: is there a possible problem with a collision with a future field called `index` ? If yes what could be done to mitigate this? Is it possible to separate into $row['index'] and $row['data'] where the latter would be the field indexed data structure currently in `$row`? If not because this structure goes into core Views -- haven't stepped through the whole thing yes, just reading it -- then at least name thing much less likely to collide like `__index` maybe?